### PR TITLE
Consistency flag on challenge field

### DIFF
--- a/model/src/main/java/org/gluu/fido2/model/entry/Fido2Entry.java
+++ b/model/src/main/java/org/gluu/fido2/model/entry/Fido2Entry.java
@@ -26,7 +26,7 @@ public class Fido2Entry extends BaseEntry {
     @AttributeName(ignoreDuringUpdate = true, name = "oxId")
     private String id;
 
-    @AttributeName(name = "oxCodeChallenge")
+    @AttributeName(name = "oxCodeChallenge", consistency = true)
     private String challange;
 
     @AttributeName(name = "oxCodeChallengeHash")


### PR DESCRIPTION
Hi,

I was testing Fido2 with couchbase setup. And sometimes during high load search queries don't return the entry which was inserted just before the search.

I solved the problem by adding consistency flag to the challenge field.