### PR TITLE
timeout default value correction

### DIFF
--- a/server/src/main/java/org/gluu/fido2/service/verifier/CommonVerifiers.java
+++ b/server/src/main/java/org/gluu/fido2/service/verifier/CommonVerifiers.java
@@ -436,14 +436,14 @@ public class CommonVerifiers {
 		}
 	}
 
-	public int verifyTimeout(JsonNode params) {
-        int timeout = 90;
+    public int verifyTimeout(JsonNode params) {
+        int timeout = 90 * 1000;
         if (params.hasNonNull("timeout")) {
-        	timeout = params.get("timeout").asInt(timeout);
+            timeout = params.get("timeout").asInt(timeout);
         }
 
         return timeout;
-	}
+    }
 
     public void verifyThatMetadataIsValid(JsonNode metadata) {
         long count = Arrays.asList(metadata.hasNonNull("aaguid"), metadata.hasNonNull("assertionScheme"), metadata.hasNonNull("attestationTypes"),


### PR DESCRIPTION
Timeout based on WebAuthn is expressed in milliseconds not seconds. The spec's suggested default value is between 20 and 120 seconds (thus 20000 and 120000). I think the default value here (90ms), was inserted having seconds in mind.
More info at https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout