### PR TITLE
fix(fido2): TPM Assertion and Attestation

### DIFF
--- a/server/src/main/java/org/gluu/fido2/service/processor/assertion/TPMAssertionFormatProcessor.java
+++ b/server/src/main/java/org/gluu/fido2/service/processor/assertion/TPMAssertionFormatProcessor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018 Mastercard
+ * Copyright (c) 2020 Gluu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.gluu.fido2.service.processor.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.gluu.fido2.ctap.AttestationFormat;
+import org.gluu.fido2.ctap.AuthenticatorAttachment;
+import org.gluu.fido2.exception.Fido2CompromisedDevice;
+import org.gluu.fido2.exception.Fido2RuntimeException;
+import org.gluu.fido2.model.auth.AuthData;
+import org.gluu.fido2.model.entry.Fido2AuthenticationData;
+import org.gluu.fido2.model.entry.Fido2RegistrationData;
+import org.gluu.fido2.service.AuthenticatorDataParser;
+import org.gluu.fido2.service.Base64Service;
+import org.gluu.fido2.service.CoseService;
+import org.gluu.fido2.service.DataMapperService;
+import org.gluu.fido2.service.processors.AssertionFormatProcessor;
+import org.gluu.fido2.service.verifier.AuthenticatorDataVerifier;
+import org.gluu.fido2.service.verifier.CommonVerifiers;
+import org.gluu.fido2.service.verifier.UserVerificationVerifier;
+import org.slf4j.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.security.PublicKey;
+
+@ApplicationScoped
+public class TPMAssertionFormatProcessor implements AssertionFormatProcessor {
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private CoseService coseService;
+
+    @Inject
+    private CommonVerifiers commonVerifiers;
+
+    @Inject
+    private AuthenticatorDataVerifier authenticatorDataVerifier;
+
+    @Inject
+    private UserVerificationVerifier userVerificationVerifier;
+
+    @Inject
+    private AuthenticatorDataParser authenticatorDataParser;
+
+    @Inject
+    private DataMapperService dataMapperService;
+
+    @Inject
+    private Base64Service base64Service;
+
+    @Override
+    public AttestationFormat getAttestationFormat() {
+        return AttestationFormat.tpm;
+    }
+
+    @Override
+    public void process(String base64AuthenticatorData, String signature, String clientDataJson, Fido2RegistrationData registration,
+                        Fido2AuthenticationData authenticationEntity) {
+        AuthData authData = authenticatorDataParser.parseAssertionData(base64AuthenticatorData);
+        commonVerifiers.verifyRpIdHash(authData, registration.getDomain());
+
+        log.debug("User verification option {}", authenticationEntity.getUserVerificationOption());
+        userVerificationVerifier.verifyUserVerificationOption(authenticationEntity.getUserVerificationOption(), authData);
+
+        byte[] clientDataHash = DigestUtils.getSha256Digest().digest(base64Service.urlDecode(clientDataJson));
+
+        try {
+            int counter = authenticatorDataParser.parseCounter(authData.getCounters());
+            commonVerifiers.verifyCounter(registration.getCounter(), counter);
+            registration.setCounter(counter);
+
+            JsonNode uncompressedECPointNode = dataMapperService.cborReadTree(base64Service.urlDecode(registration.getUncompressedECPoint()));
+            PublicKey publicKey = coseService.createUncompressedPointFromCOSEPublicKey(uncompressedECPointNode);
+
+            log.debug("Uncompressed ECPoint node {}", uncompressedECPointNode);
+            log.debug("EC Public key hex {}", Hex.encodeHexString(publicKey.getEncoded()));
+            // apple algorithm = -7
+            // windows hello algorithm is -257
+            int algorithm = registration.getAttenstationRequest().contains(AuthenticatorAttachment.PLATFORM.getAttachment()) ? -257 : registration.getSignatureAlgorithm();
+            log.debug("registration.getSignatureAlgorithm(): " + registration.getSignatureAlgorithm());
+            log.debug("Platform authenticator: " + algorithm);
+            authenticatorDataVerifier.verifyAssertionSignature(authData, clientDataHash, signature, publicKey, algorithm);
+
+        } catch (Fido2CompromisedDevice ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new Fido2RuntimeException("Failed to check tpm assertion", ex);
+        }
+    }
+}

--- a/server/src/main/java/org/gluu/fido2/service/processor/attestation/TPMProcessor.java
+++ b/server/src/main/java/org/gluu/fido2/service/processor/attestation/TPMProcessor.java
@@ -14,7 +14,6 @@
 package org.gluu.fido2.service.processor.attestation;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -96,7 +95,10 @@ public class TPMProcessor implements AttestationFormatProcessor {
             throw new Fido2RuntimeException("Problem with TPM attestation");
         }
 
-        byte[] hashedBuffer = getHashedBuffer(cborPublicKey.get("3").asInt(), authData.getAttestationBuffer(), clientDataHash);
+        verifyVersion2(attStmt);
+        int alg = verifyAlg(attStmt);
+
+        byte[] hashedBuffer = getHashedBuffer(alg, authData.getAttestationBuffer(), clientDataHash);
         byte[] keyBufferFromAuthData = base64Service.decode(cborPublicKey.get("-1").asText());
 
         Iterator<JsonNode> i = attStmt.get("x5c").elements();
@@ -126,7 +128,7 @@ public class TPMProcessor implements AttestationFormatProcessor {
             byte[] certInfoBuffer = base64Service.decode(certInfo);
             byte[] signatureBytes = base64Service.decode(signature.getBytes());
 
-            signatureVerifier.verifySignature(signatureBytes, certInfoBuffer, aikCertificate, authData.getKeyType());
+            signatureVerifier.verifySignature(signatureBytes, certInfoBuffer, aikCertificate, alg);
 
             byte[] pubAreaBuffer = base64Service.decode(pubArea);
             TPMT_PUBLIC tpmtPublic = TPMT_PUBLIC.fromTpm(pubAreaBuffer);
@@ -136,6 +138,10 @@ public class TPMProcessor implements AttestationFormatProcessor {
             verifyTPMSCertificateName(tpmtPublic, tpmsAttest, pubAreaBuffer);
             verifyTPMSExtraData(hashedBuffer, tpmsAttest.extraData);
             verifyThatKeysAreSame(tpmtPublic, keyBufferFromAuthData);
+
+            credIdAndCounters.setAttestationType(getAttestationFormat().getFmt());
+            credIdAndCounters.setCredId(base64Service.urlEncodeToString(authData.getCredId()));
+            credIdAndCounters.setUncompressedEcPoint(base64Service.urlEncodeToString(authData.getCosePublicKey()));
 
         } else {
             throw new Fido2RuntimeException("Problem with TPM attestation. Unsupported");
@@ -188,10 +194,9 @@ public class TPMProcessor implements AttestationFormatProcessor {
 
     private byte[] getHashedBuffer(int digestAlgorith, byte[] authenticatorDataBuffer, byte[] clientDataHashBuffer) {
         MessageDigest hashedBufferDigester = signatureVerifier.getDigest(digestAlgorith);
-        byte[] b1 = authenticatorDataBuffer;
-        byte[] b2 = clientDataHashBuffer;
-        byte[] buffer = ByteBuffer.allocate(b1.length + b2.length).put(b1).put(b2).array();
-        return hashedBufferDigester.digest(buffer);
+        hashedBufferDigester.update(authenticatorDataBuffer);
+        hashedBufferDigester.update(clientDataHashBuffer);
+        return hashedBufferDigester.digest();
     }
 
     private void verifyTPMCertificateExtenstion(X509Certificate aikCertificate, AuthData authData) {
@@ -211,5 +216,27 @@ public class TPMProcessor implements AttestationFormatProcessor {
             log.warn("Problem with AIK certificate {}", e.getMessage());
             throw new Fido2RuntimeException("Problem with TPM attestation");
         }
+    }
+
+    private void verifyVersion2(JsonNode attStmt) {
+        if (!attStmt.has("ver")) {
+            log.error("TPM does not contain the ver");
+            throw new Fido2RuntimeException("TPM does not contain the 'ver'");
+        }
+        String version = attStmt.get("ver").asText();
+        if (!version.equals("2.0")) {
+            log.error("TPM invalid version, ver 2.0 is required");
+            throw new Fido2RuntimeException("TPM invalid version, ver 2.0 is required");
+        }
+    }
+
+    private int verifyAlg(JsonNode attStmt) {
+        if (!attStmt.has("alg")) {
+            log.error("TPM does not contain the alg");
+            throw new Fido2RuntimeException("TPM does not contain the 'alg'");
+        }
+        int alg = attStmt.get("alg").asInt();
+        log.trace("TPM attStmt 'alg': {}", alg);
+        return alg;
     }
 }

--- a/server/src/main/java/org/gluu/fido2/service/verifier/SignatureVerifier.java
+++ b/server/src/main/java/org/gluu/fido2/service/verifier/SignatureVerifier.java
@@ -95,7 +95,7 @@ public class SignatureVerifier {
                 return signatureChecker;
             }
             case -65535: {
-                Signature signatureChecker = Signature.getInstance("SHA1withRSA", provider);
+                Signature signatureChecker = Signature.getInstance("SHA1withRSA");
                 return signatureChecker;
             }
 


### PR DESCRIPTION
### Description
- Improvement in `getHashedBuffer` method
- Modified the `signatureAlgorithm` parameter of the `verifySignature` method to `attStmt.alg` field
- Added `verifyVersion2` method
- Added `verifyAlg` method
  
closes #55
